### PR TITLE
Add prerequisites needed to run to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Cxbx-Reloaded is early in development and still pretty unstable, so don't expect
 ### Minimum
   * OS: Windows 7 64-bit or newer. 32-bit installations are not supported.
   * Video card: anything that supports Direct3D 8.
+### Prerequisites
+  * [Visual C++ 2015 Redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
   
 ## Automated Builds
 Cxbx-Reloaded is not yet ready for general release, but the latest development build can always be downloaded from our [AppVeyor](https://ci.appveyor.com/project/SoullessSentinel/cxbx-reloaded/branch/master) (navigate to Configuration: Release => Artifacts => export\Release.zip).


### PR DESCRIPTION
Without installing Visual C++ Redistributable, Cxbx-Reloaded does not run. Add this to the README for clarification.